### PR TITLE
Update CI after open-sourcing

### DIFF
--- a/concourse/pipeline.py
+++ b/concourse/pipeline.py
@@ -18,15 +18,15 @@ DEFAULT_IMAGE = {
 }
 
 with Pipeline("pipeline-dsl", team="garden", image_resource=DEFAULT_IMAGE) as pipeline:
-    repo_url = "https://github.com/SAP/pipeline-dsl"
+    repo_url = "git@github.com:SAP/pipeline-dsl.git"
     pipeline.resource(
         "pipeline-dsl",
-        GitRepo(repo_url, username="akhinos", password="((GITHUB_TOKEN))", ignore_paths=["concourse/*", "doc/*"], branch="main"),
+        GitRepo(repo_url, private_key="((GITHUB_COM_DEPLOY_KEY))", ignore_paths=["concourse/*", "doc/*"], branch="main"),
     )
 
     pipeline.resource(
         "pipeline-dsl-stable",
-        GitRepo(repo_url, username="akhinos", password="((GITHUB_TOKEN))", ignore_paths=["concourse/*"], branch="stable"),
+        GitRepo(repo_url, private_key="((GITHUB_COM_DEPLOY_KEY))", ignore_paths=["concourse/*"], branch="stable"),
     )
 
     with pipeline.job("test") as job:

--- a/concourse/pipeline.py
+++ b/concourse/pipeline.py
@@ -1,4 +1,4 @@
-from conpype import Pipeline, GitRepo, shell
+from pipeline_dsl import Pipeline, GitRepo, shell
 import urllib.request
 import os
 import stat
@@ -17,34 +17,35 @@ DEFAULT_IMAGE = {
     },
 }
 
-with Pipeline("conpype", team="garden", image_resource=DEFAULT_IMAGE) as pipeline:
+with Pipeline("pipeline-dsl", team="garden", image_resource=DEFAULT_IMAGE) as pipeline:
+    repo_url = "https://github.com/SAP/pipeline-dsl"
     pipeline.resource(
-        "conpype",
-        GitRepo("https://github.tools.sap/cki/conpype", username="istio-serviceuser", password="((GITHUB_TOOLS_SAP_TOKEN))", ignore_paths=["concourse/*", "doc/*"], branch="develop"),
+        "pipeline-dsl",
+        GitRepo(repo_url, username="akhinos", password="((GITHUB_TOKEN))", ignore_paths=["concourse/*", "doc/*"], branch="main"),
     )
 
     pipeline.resource(
-        "conpype-main",
-        GitRepo("https://github.tools.sap/cki/conpype", username="istio-serviceuser", password="((GITHUB_TOOLS_SAP_TOKEN))", ignore_paths=["concourse/*"], branch="main"),
+        "pipeline-dsl-stable",
+        GitRepo(repo_url, username="akhinos", password="((GITHUB_TOKEN))", ignore_paths=["concourse/*"], branch="stable"),
     )
 
     with pipeline.job("test") as job:
-        job.get("conpype", trigger=True)
+        job.get("pipeline-dsl", trigger=True)
 
         @job.task()
         def install_and_test():
-            shell(["make", "install"], cwd="conpype")
+            shell(["make", "install"], cwd="pipeline-dsl")
             urllib.request.urlretrieve("https://cki-concourse.istio.sapcloud.io/api/v1/cli?arch=amd64&platform=linux", "/usr/bin/fly")
             os.chmod("/usr/bin/fly", stat.S_IEXEC | stat.S_IREAD)
-            shell(["make", "test"], cwd="conpype")
+            shell(["make", "test"], cwd="pipeline-dsl")
 
     with pipeline.job("coverage") as job:
-        job.get("conpype", trigger=True)
+        job.get("pipeline-dsl", trigger=True)
 
         @job.task()
         def ensure_coverage():
-            shell(["make", "coverage"], cwd="conpype")
-            repjson = subprocess.check_output(["coverage", "json", "-o", "-"], cwd="conpype")
+            shell(["make", "coverage"], cwd="pipeline-dsl")
+            repjson = subprocess.check_output(["coverage", "json", "-o", "-"], cwd="pipeline-dsl")
             report = json.loads(repjson)
             percentage = report["totals"]["percent_covered"]
 
@@ -54,4 +55,4 @@ with Pipeline("conpype", team="garden", image_resource=DEFAULT_IMAGE) as pipelin
                 sys.exit(1)
             print(f"Coverage over {COVERAGE_THRESHOLD}%! Coverage check passed.")
 
-        job.put("conpype-main", params={"repository": "conpype"})
+        job.put("pipeline-dsl-stable", params={"repository": "pipeline-dsl"})

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -54,7 +54,7 @@ GoogleCloudStorageResource("my-bucket", "(.*).txt", "((MY_GCS_CREDENTIALS))")
 
 Upstream resource documentation: https://github.com/concourse/git-resource/blob/master/README.md
 
-Note: Only `uri`, `username`, `password`, `branch`, `ignore_paths` and `tag_filter` are currently supported supported in source configuration.
+Note: Only `uri`, `username`, `password`, `branch`, `ignore_paths`, `tag_filter`, `git_config` and `private_key` are currently supported supported in source configuration.
 
 Example:
 ```python

--- a/pipeline_dsl/resources/git.py
+++ b/pipeline_dsl/resources/git.py
@@ -40,7 +40,7 @@ class GitRepoResource:
 
 
 class GitRepo:
-    def __init__(self, uri, username=None, password=None, branch=None, paths=None, ignore_paths=None, tag_filter=None, git_config={}):
+    def __init__(self, uri, username=None, password=None, branch=None, paths=None, ignore_paths=None, tag_filter=None, git_config={}, private_key=None):
         self.uri = uri
         self.username = username
         self.password = password
@@ -49,6 +49,7 @@ class GitRepo:
         self.ignore_paths = ignore_paths
         self.tag_filter = tag_filter
         self.git_config = git_config
+        self.private_key = private_key
 
     def resource_type(self):
         return None
@@ -67,6 +68,7 @@ class GitRepo:
                 "ignore_paths": self.ignore_paths,
                 "tag_filter": self.tag_filter,
                 "git_config": list(map(lambda kv: {"name": kv[0], "value": kv[1]}, self.git_config.items())),
+                "private_key": self.private_key,
             },
         }
         result["source"] = dict(filter(lambda x: x[1] is not None, result["source"].items()))


### PR DESCRIPTION
1. Changed the import to `pipeline_dsl`
2. Changed the resources to the new repo.
3. Removed all references to `conpype` in names of jobs, tasks, resources, etc..
4. The pipeline will pick from `main` and push to `stable` as we currently don't have a `develop` branch. But we could also change this.

I does not work as our technical user lacks the permissions to push to the Repo. Currently, only @kramerul  can change this.
 