### PR TITLE
Explicitly use python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 SHELL := /bin/bash
 
 build: pipeline_dsl/*.py
-	python setup.py build
+	python3 setup.py build
 
 install: build
-	python setup.py install
+	python3 setup.py install
 
 test: test-examples test-unit
 
@@ -12,11 +12,11 @@ test-examples:
 	@set -euo pipefail; \
 	for i in examples/*.py; do \
 		echo $$i; \
-		fly vp -c <(PYTHONPATH=$$(pwd) python $$i --dump); \
+		fly vp -c <(PYTHONPATH=$$(pwd) python3 $$i --dump); \
 	done
 	
 test-unit:
-	PYTHONPATH=$$(pwd) python -m"unittest"
+	PYTHONPATH=$$(pwd) python3 -m"unittest"
 
 coverage:
 	PYTHONPATH=$$(pwd) coverage run -m unittest

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ```bash
 brew install gnu-tar
-pip install --upgrade git+https://github.com/sap/pipeline-dsl.git@main
+pip3 install --upgrade git+https://github.com/sap/pipeline-dsl.git@main
 ```
 
 ## Example

--- a/doc/user.md
+++ b/doc/user.md
@@ -157,7 +157,7 @@ with Pipeline("test") as pipeline:
 It's possible to execute each task locally
 
 ```
-python <pipeline> --job <job> --task <task>
+python3 <pipeline> --job <job> --task <task>
 ```
 
 In this case

--- a/pipeline_dsl/test/test_pipeline.py
+++ b/pipeline_dsl/test/test_pipeline.py
@@ -96,4 +96,4 @@ class TestPipeline(unittest.TestCase):
 if __name__ == "__main__":
     unittest.main()
 
-# run > python -munittest in main pipeline-dsl dir to execute
+# run > python3 -munittest in main pipeline-dsl dir to execute

--- a/pipeline_dsl/test/test_resource.py
+++ b/pipeline_dsl/test/test_resource.py
@@ -307,4 +307,4 @@ class TestGithubPRResource(unittest.TestCase):
 if __name__ == "__main__":
     unittest.main()
 
-# run > python -munittest in main pipeline-dsl dir to execute
+# run > python3 -munittest in main pipeline-dsl dir to execute


### PR DESCRIPTION
`python` is usually a symlink to either `python3` or `python2`.
As we require python 3 we should be explicit about this.