### PR TITLE
replace shellout to tar with pythons built-in tarfile package

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 ## Installation
 
 ```bash
-brew install gnu-tar
 pip3 install --upgrade git+https://github.com/sap/pipeline-dsl.git@main
 ```
 


### PR DESCRIPTION
Currently, when serializing the pipeline to yaml, we use a shellout to `tar`.
To make this as idempotent as possible (preventing `fly` to display diffs when nothing actually changed) we  use several flags not supported by the macOS version of tar. This creates an awkward dependency on `brew install gnu-tar` for all mac users (don't even know about Windows users, probably something similar).

Besides this, programmatically calling executables to do some task is always ugly (e.g. does not integrate with the native error-handling of python).

Fortunately, there is a package called `tarfile` in the standard library of python, which can do the job here. This PR swaps out the implementation and updates the installation instructions.
