### PR TITLE
Fix task input issue

### DIFF
--- a/pipeline_dsl/concourse/job.py
+++ b/pipeline_dsl/concourse/job.py
@@ -51,11 +51,13 @@ class Job:
         self.inputs.append(name)
         return resource_chain.resource.get(name)
 
-    def task(self, image_resource=None, **kwargs):
+    def task(self, image_resource=None, inputs=None, **kwargs):
         if not image_resource:
             image_resource = self.image_resource
 
         def decorate(fun):
+            if inputs:
+                self.inputs.append(inputs)
             task = Task(fun=fun, jobname=self.name, secret_manager=self.secret_manager, image_resource=image_resource, script=self.script, inputs=self.inputs, **kwargs)
 
             self.plan.append(task)


### PR DESCRIPTION
## Motivation
At the moment it is quite cumbersome and unintuitive to write a task that uses the outputs of another task as input.
Example: 
```python
[...]
with pipeline.job("my-job") as job:

    @job.task(outputs=["out"])
    def task_output(test):
        pass

    job.inputs.append("out")

    @job.task()
     def task_input():
        pass
```
When trying to add the inputs to the decorator (e.g. `@job.task(inputs=["out"])`) it fails with `pipeline_dsl.concourse.task.Task() got multiple values for keyword argument 'inputs` because the inputs for the `task` are [already specified](https://github.com/SAP/pipeline-dsl/blob/ed06deefca11fb863c9aabd4d3fffe538e8926e1/pipeline_dsl/concourse/job.py#L59) and can't be replaced with the inputs provided by the kwargs.

## Solution
When adding the inputs argument explicitly like the [image_resource](https://github.com/SAP/pipeline-dsl/blob/ed06deefca11fb863c9aabd4d3fffe538e8926e1/pipeline_dsl/concourse/job.py#L54), the decorator can take the inputs via `@job.task(inputs=["out"])`.
This will improve the understanding and readability of pipelines created with pipeline_dsl.
Example:
```python
[...]
with pipeline.job("my-job") as job:

    @job.task(outputs=["out"])
    def task_output(test):
        pass

    @job.task(inputs=["out"])
     def task_input():
        pass
```

## Notes
This would introduce a new test for `tasks`, as there is no test for `tasks` at the moment.
Does it make sense to add a new full test for `tasks` or is the check for the `inputs` and `outputs` sufficient here?  