### PR TITLE
Introduce Resource Interface

### DIFF
--- a/pipeline_dsl/resources/__init__.py
+++ b/pipeline_dsl/resources/__init__.py
@@ -8,6 +8,7 @@ from pipeline_dsl.resources.cron import Cron
 from pipeline_dsl.resources.registry_image import RegistryImage
 from pipeline_dsl.resources.github_pr import GithubPR
 from pipeline_dsl.resources.pypi import PyPi
+from pipeline_dsl.resources.resource import ConcourseResource
 
 ConcourseLockResource = Pool
 GoogleCloudStorageResource = GoogleCloudStorage

--- a/pipeline_dsl/resources/pool.py
+++ b/pipeline_dsl/resources/pool.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, Collection
+from typing import Optional, Dict
 from pipeline_dsl.resources.resource import AbstractResource, ConcourseResource
 
 

--- a/pipeline_dsl/resources/pool.py
+++ b/pipeline_dsl/resources/pool.py
@@ -1,5 +1,5 @@
 from typing import Optional, Dict, Collection
-from pipeline_dsl.resources.resource import AbstractResource
+from pipeline_dsl.resources.resource import AbstractResource, ConcourseResource
 
 
 class Pool(AbstractResource):
@@ -20,20 +20,20 @@ class Pool(AbstractResource):
             },
         }
 
-    def get(self, name: str) -> 'Pool':
+    def get(self, name: str) -> "Pool":
         return self
 
-    def concourse(self, name: str) -> Dict[str, Collection[str]]:
-        result = {
-            "name": name,
-            "type": "pool-stable",
-            "icon": "lock",
-            "source": {
+    def concourse(self, name: str) -> ConcourseResource:
+        result = ConcourseResource(
+            name=name,
+            type="pool-stable",
+            icon="lock",
+            source={
                 "uri": self.uri,
                 "branch": self.branch,
                 "pool": self.pool,
                 "username": self.username,
                 "password": self.password,
             },
-        }
+        )
         return result

--- a/pipeline_dsl/resources/pool.py
+++ b/pipeline_dsl/resources/pool.py
@@ -1,12 +1,16 @@
-class Pool:
-    def __init__(self, uri, branch, pool, username, password):
+from typing import Optional, Dict, Collection
+from pipeline_dsl.resources.resource import AbstractResource
+
+
+class Pool(AbstractResource):
+    def __init__(self, uri: str, branch: str, pool: str, username: str, password: str):
         self.uri = uri
         self.branch = branch
         self.pool = pool
         self.username = username
         self.password = password
 
-    def resource_type(self):
+    def resource_type(self) -> Optional[Dict]:
         return {
             "name": "pool-stable",
             "type": "docker-image",
@@ -16,10 +20,10 @@ class Pool:
             },
         }
 
-    def get(self, name):
+    def get(self, name: str) -> 'Pool':
         return self
 
-    def concourse(self, name):
+    def concourse(self, name: str) -> Dict[str, Collection[str]]:
         result = {
             "name": name,
             "type": "pool-stable",

--- a/pipeline_dsl/resources/pypi.py
+++ b/pipeline_dsl/resources/pypi.py
@@ -1,10 +1,14 @@
-class PyPi:
-    def __init__(self, name, username, password):
+from typing import Optional, Dict, Collection
+from pipeline_dsl.resources.resource import AbstractResource
+
+
+class PyPi(AbstractResource):
+    def __init__(self, name: str, username: str, password: str):
         self.name = name
         self.username = username
         self.password = password
 
-    def resource_type(self):
+    def resource_type(self) -> Optional[Dict]:
         return {
             "name": "pypi",
             "type": "docker-image",
@@ -14,10 +18,10 @@ class PyPi:
             },
         }
 
-    def get(self, name):
+    def get(self, name: str) -> 'PyPi':
         return self
 
-    def concourse(self, name):
+    def concourse(self, name) -> Dict[str, Collection[str]]:
         result = {
             "name": name,
             "type": "pypi",

--- a/pipeline_dsl/resources/pypi.py
+++ b/pipeline_dsl/resources/pypi.py
@@ -1,5 +1,5 @@
 from typing import Optional, Dict, Collection
-from pipeline_dsl.resources.resource import AbstractResource
+from pipeline_dsl.resources.resource import AbstractResource, ConcourseResource
 
 
 class PyPi(AbstractResource):
@@ -18,20 +18,20 @@ class PyPi(AbstractResource):
             },
         }
 
-    def get(self, name: str) -> 'PyPi':
+    def get(self, name: str) -> "PyPi":
         return self
 
-    def concourse(self, name) -> Dict[str, Collection[str]]:
-        result = {
-            "name": name,
-            "type": "pypi",
-            "icon": "language-python",
-            "source": {
+    def concourse(self, name) -> ConcourseResource:
+        result = ConcourseResource(
+            name=name,
+            type="pypi",
+            icon="language-python",
+            source={
                 "name": self.name,
                 "repository": {
                     "username": self.username,
                     "password": self.password,
                 },
             },
-        }
+        )
         return result

--- a/pipeline_dsl/resources/pypi.py
+++ b/pipeline_dsl/resources/pypi.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, Collection
+from typing import Optional, Dict
 from pipeline_dsl.resources.resource import AbstractResource, ConcourseResource
 
 
@@ -21,7 +21,7 @@ class PyPi(AbstractResource):
     def get(self, name: str) -> "PyPi":
         return self
 
-    def concourse(self, name) -> ConcourseResource:
+    def concourse(self, name: str) -> ConcourseResource:
         result = ConcourseResource(
             name=name,
             type="pypi",

--- a/pipeline_dsl/resources/registry_image.py
+++ b/pipeline_dsl/resources/registry_image.py
@@ -1,17 +1,18 @@
-import os
-from pipeline_dsl.concourse import concourse_context
 from pipeline_dsl.resources.resource import AbstractResource
+from pipeline_dsl.concourse import concourse_context
+from typing import Dict, Optional, Collection, Union
+import os
 
 
 class RegistryImageResource:
-    def __init__(self, name):
+    def __init__(self, name: str):
         self.name = name
         self.path = os.path.abspath(self.name)
 
     def __str__(self):
         return self.name
 
-    def tag(self, default=None):
+    def tag(self, default: Optional[str] = None) -> Optional[str]:
         if concourse_context():
             with open(os.path.join(self.path, "tag")) as f:
                 return f.read().strip()
@@ -26,10 +27,10 @@ class RegistryImage(AbstractResource[RegistryImageResource]):
         self.tag = tag
         self.variant = variant
 
-    def resource_type(self) -> dict:
+    def resource_type(self) -> Optional[Dict]:
         return None
 
-    def concourse(self, name: str) -> dict:
+    def concourse(self, name: str) -> Dict[str, Collection[str]]:
         result = {
             "name": name,
             "type": "registry-image",

--- a/pipeline_dsl/resources/registry_image.py
+++ b/pipeline_dsl/resources/registry_image.py
@@ -1,6 +1,6 @@
 from pipeline_dsl.resources.resource import AbstractResource, ConcourseResource
 from pipeline_dsl.concourse import concourse_context
-from typing import Dict, Optional, Collection, Union
+from typing import Dict, Optional
 import os
 
 
@@ -9,7 +9,7 @@ class RegistryImageResource:
         self.name = name
         self.path = os.path.abspath(self.name)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
     def tag(self, default: Optional[str] = None) -> Optional[str]:

--- a/pipeline_dsl/resources/registry_image.py
+++ b/pipeline_dsl/resources/registry_image.py
@@ -1,4 +1,4 @@
-from pipeline_dsl.resources.resource import AbstractResource
+from pipeline_dsl.resources.resource import AbstractResource, ConcourseResource
 from pipeline_dsl.concourse import concourse_context
 from typing import Dict, Optional, Collection, Union
 import os
@@ -30,20 +30,21 @@ class RegistryImage(AbstractResource[RegistryImageResource]):
     def resource_type(self) -> Optional[Dict]:
         return None
 
-    def concourse(self, name: str) -> Dict[str, Collection[str]]:
-        result = {
-            "name": name,
-            "type": "registry-image",
-            "source": {
+    def concourse(self, name: str) -> ConcourseResource:
+        result = ConcourseResource(
+            name=name,
+            type="registry-image",
+            icon="docker",
+            source={
                 "repository": self.repo,
                 "username": self.username,
                 "password": self.password,
                 "tag": self.tag,
                 "variant": self.variant,
             },
-        }
-        result["source"] = dict(
-            filter(lambda x: x[1] is not None, result["source"].items()),
+        )
+        result.source = dict(
+            filter(lambda x: x[1] is not None, result.source.items()),
         )
         return result
 

--- a/pipeline_dsl/resources/registry_image.py
+++ b/pipeline_dsl/resources/registry_image.py
@@ -1,5 +1,6 @@
 import os
 from pipeline_dsl.concourse import concourse_context
+from pipeline_dsl.resources.resource import AbstractResource
 
 
 class RegistryImageResource:
@@ -17,18 +18,18 @@ class RegistryImageResource:
         return default
 
 
-class RegistryImage:
-    def __init__(self, repo, username=None, password=None, tag=None, variant=None):
+class RegistryImage(AbstractResource):
+    def __init__(self, repo: str, username: str = None, password: str = None, tag: str = None, variant: str = None):
         self.repo = repo
         self.username = username
         self.password = password
         self.tag = tag
         self.variant = variant
 
-    def resource_type(self):
+    def resource_type(self) -> dict:
         return None
 
-    def concourse(self, name):
+    def concourse(self, name: str) -> dict:
         result = {
             "name": name,
             "type": "registry-image",
@@ -45,5 +46,5 @@ class RegistryImage:
         )
         return result
 
-    def get(self, name):
+    def get(self, name: str):
         return RegistryImageResource(name)

--- a/pipeline_dsl/resources/registry_image.py
+++ b/pipeline_dsl/resources/registry_image.py
@@ -18,7 +18,7 @@ class RegistryImageResource:
         return default
 
 
-class RegistryImage(AbstractResource):
+class RegistryImage(AbstractResource[RegistryImageResource]):
     def __init__(self, repo: str, username: str = None, password: str = None, tag: str = None, variant: str = None):
         self.repo = repo
         self.username = username
@@ -46,5 +46,5 @@ class RegistryImage(AbstractResource):
         )
         return result
 
-    def get(self, name: str):
+    def get(self, name: str) -> RegistryImageResource:
         return RegistryImageResource(name)

--- a/pipeline_dsl/resources/resource.py
+++ b/pipeline_dsl/resources/resource.py
@@ -1,8 +1,17 @@
-from typing import TypeVar, Generic, Optional, Dict, Collection
+from typing import TypeVar, Generic, Optional, Dict, Any
 from abc import abstractmethod
+from dataclasses import dataclass
 
 
-T = TypeVar('T')
+T = TypeVar("T")
+
+
+@dataclass
+class ConcourseResource:
+    name: str
+    type: str
+    icon: str
+    source: Dict[str, Any]
 
 
 class AbstractResource(Generic[T]):
@@ -11,7 +20,7 @@ class AbstractResource(Generic[T]):
         pass
 
     @abstractmethod
-    def concourse(self, name: str) -> Dict[str, Collection[str]]:
+    def concourse(self, name: str) -> ConcourseResource:
         pass
 
     @abstractmethod

--- a/pipeline_dsl/resources/resource.py
+++ b/pipeline_dsl/resources/resource.py
@@ -1,7 +1,10 @@
-from abc import ABC, abstractmethod
+from abc import abstractmethod
+from typing import TypeVar, Generic
 
 
-class AbstractResource(ABC):
+T = TypeVar('T')
+
+class AbstractResource(Generic[T]):
     @abstractmethod
     def resource_type(self) -> dict:
         pass
@@ -11,5 +14,5 @@ class AbstractResource(ABC):
         pass
 
     @abstractmethod
-    def get(self, name: str):
+    def get(self, name: str) -> T:
         pass

--- a/pipeline_dsl/resources/resource.py
+++ b/pipeline_dsl/resources/resource.py
@@ -1,16 +1,17 @@
+from typing import TypeVar, Generic, Optional, Dict, Collection
 from abc import abstractmethod
-from typing import TypeVar, Generic
 
 
 T = TypeVar('T')
 
+
 class AbstractResource(Generic[T]):
     @abstractmethod
-    def resource_type(self) -> dict:
+    def resource_type(self) -> Optional[Dict]:
         pass
 
     @abstractmethod
-    def concourse(self, name: str) -> dict:
+    def concourse(self, name: str) -> Dict[str, Collection[str]]:
         pass
 
     @abstractmethod

--- a/pipeline_dsl/resources/resource.py
+++ b/pipeline_dsl/resources/resource.py
@@ -1,0 +1,15 @@
+from abc import ABC, abstractmethod
+
+
+class AbstractResource(ABC):
+    @abstractmethod
+    def resource_type(self) -> dict:
+        pass
+
+    @abstractmethod
+    def concourse(self, name: str) -> dict:
+        pass
+
+    @abstractmethod
+    def get(self, name: str):
+        pass

--- a/pipeline_dsl/test/test_resource.py
+++ b/pipeline_dsl/test/test_resource.py
@@ -1,6 +1,6 @@
 import unittest
 import os
-from pipeline_dsl.resources import GitRepo, Cron, DockerImage, GoogleCloudStorage, Pool, GithubRelease, SemVer, SemVerGitDriver, RegistryImage, GithubPR
+from pipeline_dsl.resources import GitRepo, Cron, DockerImage, GoogleCloudStorage, Pool, GithubRelease, SemVer, SemVerGitDriver, RegistryImage, GithubPR, ConcourseResource
 from pipeline_dsl.concourse.__shared import concourse_ctx
 
 
@@ -130,20 +130,20 @@ class TestPoolResource(unittest.TestCase):
         resource = Pool("uri", "branch", "pool", "username", "password")
 
         obj = resource.concourse("test")
-        self.assertDictEqual(
+        self.assertEqual(
             obj,
-            {
-                "name": "test",
-                "type": "pool-stable",
-                "icon": "lock",
-                "source": {
+            ConcourseResource(
+                name="test",
+                type="pool-stable",
+                icon="lock",
+                source={
                     "uri": "uri",
                     "branch": "branch",
                     "pool": "pool",
                     "username": "username",
                     "password": "password",
                 },
-            },
+            ),
         )
 
         self.assertDictEqual(
@@ -266,19 +266,20 @@ class TestRegistryImageResource(unittest.TestCase):
 
         obj = resource.concourse("test")
 
-        self.assertDictEqual(
+        self.assertEqual(
             obj,
-            {
-                "name": "test",
-                "type": "registry-image",
-                "source": {
+            ConcourseResource(
+                name="test",
+                type="registry-image",
+                icon="docker",
+                source={
                     "repository": "repo",
                     "username": "user",
                     "password": "password",
                     "tag": "tag",
                     "variant": "variant",
                 },
-            },
+            ),
         )
 
 


### PR DESCRIPTION
After experimenting with `Type Hints` for `pipeline-dsl` I found out that it could be useful to have some kind of interface or abstract class for the resource objects. We then could use the interface also for the `Type Hints`.
Unfortunately, `Type Hints` is a pretty new feature in python and it is not that mature (e.g. types like `Any` are pretty slow in `python <3.7`).
WDYT?