### PR TITLE
bump to python >=3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Pipeline DSL for [Concourse](https://concourse-ci.org/) 
 
 [![downloads](https://static.pepy.tech/badge/pipeline-dsl/month)](https://pypi.org/project/pipeline-dsl/)
-[![python](https://img.shields.io/badge/python-3.6-blue.svg)](https://pypi.org/project/pipeline-dsl/)
+[![python](https://img.shields.io/badge/python-3.7-blue.svg)](https://pypi.org/project/pipeline-dsl/)
 [![pypi](https://img.shields.io/pypi/v/pipeline-dsl.svg)](https://pypi.org/project/pipeline-dsl/)
 [![license](https://img.shields.io/pypi/l/pipeline-dsl.svg)](https://pypi.org/project/pipeline-dsl/)
 

--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,5 @@ setuptools.setup(
     install_requires=[
         "pyyaml",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
 )


### PR DESCRIPTION
This will allow us to use the `@dataclass` annotation: https://docs.python.org/3/library/dataclasses.html
Python 3.6 is basically dead, it will receive "Security fixes only, as needed, until 2021-12": https://www.python.org/dev/peps/pep-0494/#and-beyond-schedule