### PR TITLE
Make file types for scriptdirs adjustable per pipeline

### DIFF
--- a/pipeline_dsl/concourse/job.py
+++ b/pipeline_dsl/concourse/job.py
@@ -7,11 +7,11 @@ from .task import InitTask, Task
 
 
 class Job:
-    def __init__(self, name, script, init_dirs, image_resource, resource_chains, secret_manager, serial, serial_groups, old_name, groups):
+    def __init__(self, name, script, init_dirs, image_resource, resource_chains, secret_manager, serial, serial_groups, old_name, groups, file_types=None):
         self.name = name
         self.groups = groups
         self.old_name = old_name
-        self.plan = [InitTask(init_dirs, image_resource)]
+        self.plan = [InitTask(init_dirs, image_resource, file_types)]
         self.image_resource = image_resource
         self.resource_chains = resource_chains
         self.script = script

--- a/pipeline_dsl/concourse/pipeline.py
+++ b/pipeline_dsl/concourse/pipeline.py
@@ -19,7 +19,7 @@ def vault_secret_manager(key):
 
 
 class Pipeline:
-    def __init__(self, name, image_resource={"type": "registry-image", "source": {"repository": "python", "tag": "3.8-buster"}}, script_dirs={}, team="main"):
+    def __init__(self, name, image_resource={"type": "registry-image", "source": {"repository": "python", "tag": "3.8-buster"}}, script_dirs={}, file_types=None, team="main"):
         frame = inspect.stack()[1]
         module = inspect.getmodule(frame[0])
         self.script = module.__file__
@@ -42,6 +42,7 @@ class Pipeline:
         self.resource_types = {}
         self.name = name
         self.image_resource = image_resource
+        self.file_types = file_types
         self.team = team
         self.secret_manager = env_secret_manager
 
@@ -95,7 +96,17 @@ class Pipeline:
 
     def job(self, name, serial=False, serial_groups=[], old_name=None, groups=[]):
         result = Job(
-            name, self.script, self.init_dirs, self.image_resource, self.resource_chains, self.__create_secret_manager(), serial=serial, serial_groups=serial_groups, old_name=old_name, groups=groups
+            name,
+            self.script,
+            self.init_dirs,
+            self.image_resource,
+            self.resource_chains,
+            self.__create_secret_manager(),
+            serial=serial,
+            serial_groups=serial_groups,
+            old_name=old_name,
+            groups=groups,
+            file_types=self.file_types,
         )
         self.jobs.append(result)
         self.jobs_by_name[name] = result

--- a/pipeline_dsl/test/test_inittask.py
+++ b/pipeline_dsl/test/test_inittask.py
@@ -1,0 +1,11 @@
+from pipeline_dsl import InitTask
+import unittest
+
+
+class TestInitTaskSimple(unittest.TestCase):
+    def test_basic(self):
+        task = InitTask({}, "image")
+
+        obj = task.concourse()
+
+        self.assertEqual(obj["task"], "init")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 coverage>=5.5
 mock>=4.0.0
+pathlib>=1.0.0
 PyYAML>=5.3.1


### PR DESCRIPTION
Fixes #8 

This could be a simple approach for addressing the issue. The file types would still be the same for all `script_dirs` within one pipeline. But I would argue that this is good enough. 