### PR TITLE
Introduce type hints for the remaining pipeline-dsl resources

### DIFF
--- a/pipeline_dsl/resources/cron.py
+++ b/pipeline_dsl/resources/cron.py
@@ -2,7 +2,7 @@ from pipeline_dsl.resources.resource import AbstractResource, ConcourseResource
 from typing import Optional, Dict
 
 
-class Cron(AbstractResource):
+class Cron(AbstractResource[None]):
     def __init__(self, definition: str) -> None:
         self.definition = definition
 

--- a/pipeline_dsl/resources/cron.py
+++ b/pipeline_dsl/resources/cron.py
@@ -1,8 +1,12 @@
-class Cron:
-    def __init__(self, definition):
+from pipeline_dsl.resources.resource import AbstractResource, ConcourseResource
+from typing import Optional, Dict
+
+
+class Cron(AbstractResource):
+    def __init__(self, definition: str) -> None:
         self.definition = definition
 
-    def resource_type(self):
+    def resource_type(self) -> Optional[Dict]:
         return {
             "name": "cron",
             "type": "docker-image",
@@ -12,16 +16,16 @@ class Cron:
             },
         }
 
-    def concourse(self, name):
-        return {
-            "name": name,
-            "type": "cron",
-            "icon": "clock-outline",
-            "source": {
+    def concourse(self, name: str) -> ConcourseResource:
+        return ConcourseResource(
+            name=name,
+            type="cron",
+            icon="clock-outline",
+            source={
                 "cron": self.definition,
                 "location": "Europe/Berlin",
             },
-        }
+        )
 
-    def get(self, name):
+    def get(self, name: str) -> None:
         return None

--- a/pipeline_dsl/resources/docker.py
+++ b/pipeline_dsl/resources/docker.py
@@ -1,46 +1,50 @@
-import os
+from pipeline_dsl.resources.resource import AbstractResource, ConcourseResource
 from pipeline_dsl.concourse import concourse_context
+from typing import Optional, Dict
+import os
 
 
 class DockerImageResource:
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         self.name = name
         self.path = os.path.abspath(self.name)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
-    def digest(self):
+    def digest(self) -> str:
         if concourse_context():
             with open(os.path.join(self.path, "digest")) as f:
                 return f.read().strip()
         return "latest"
 
 
-class DockerImage:
-    def __init__(self, repository, username=None, password=None, tag="latest"):
+class DockerImage(AbstractResource[DockerImageResource]):
+    def __init__(self, repository: str, username: str = None, password: str = None, tag: str = "latest"):
         self.repository = repository
         self.username = username
         self.password = password
         self.tag = tag
 
-    def resource_type(self):
+    def resource_type(self) -> Optional[Dict]:
         return None
 
-    def concourse(self, name):
-        result = {
-            "name": name,
-            "type": "docker-image",
-            "icon": "docker",
-            "source": {
+    def concourse(self, name: str) -> ConcourseResource:
+        result = ConcourseResource(
+            name=name,
+            type="docker-image",
+            icon="docker",
+            source={
                 "repository": self.repository,
                 "username": self.username,
                 "password": self.password,
                 "tag": self.tag,
             },
-        }
-        result["source"] = dict(filter(lambda x: x[1] is not None, result["source"].items()))
+        )
+        result.source = dict(
+            filter(lambda x: x[1] is not None, result.source.items()),
+        )
         return result
 
-    def get(self, name):
+    def get(self, name: str) -> DockerImageResource:
         return DockerImageResource(name)

--- a/pipeline_dsl/resources/gcs.py
+++ b/pipeline_dsl/resources/gcs.py
@@ -1,10 +1,14 @@
-class GoogleCloudStorage:
-    def __init__(self, bucket, regexp, credentials):
+from pipeline_dsl.resources.resource import AbstractResource, ConcourseResource
+from typing import Optional, Dict
+
+
+class GoogleCloudStorage(AbstractResource):
+    def __init__(self, bucket: str, regexp: str, credentials: str) -> None:
         self.bucket = bucket
         self.regexp = regexp
         self.credentials = credentials
 
-    def resource_type(self):
+    def resource_type(self) -> Optional[Dict]:
         return {
             "name": "gcs",
             "type": "docker-image",
@@ -14,18 +18,18 @@ class GoogleCloudStorage:
             },
         }
 
-    def get(self, name):
+    def get(self, name: str) -> "GoogleCloudStorage":
         return self
 
-    def concourse(self, name):
-        result = {
-            "name": name,
-            "type": "gcs",
-            "icon": "file-cloud",
-            "source": {
+    def concourse(self, name: str) -> ConcourseResource:
+        result = ConcourseResource(
+            name=name,
+            type="gcs",
+            icon="file-cloud",
+            source={
                 "bucket": self.bucket,
                 "regexp": self.regexp,
                 "json_key": self.credentials,
             },
-        }
+        )
         return result

--- a/pipeline_dsl/resources/gcs.py
+++ b/pipeline_dsl/resources/gcs.py
@@ -2,7 +2,7 @@ from pipeline_dsl.resources.resource import AbstractResource, ConcourseResource
 from typing import Optional, Dict
 
 
-class GoogleCloudStorage(AbstractResource):
+class GoogleCloudStorage(AbstractResource["GoogleCloudStorage"]):
     def __init__(self, bucket: str, regexp: str, credentials: str) -> None:
         self.bucket = bucket
         self.regexp = regexp

--- a/pipeline_dsl/resources/git.py
+++ b/pipeline_dsl/resources/git.py
@@ -1,29 +1,31 @@
-import os
+from pipeline_dsl.resources.resource import AbstractResource, ConcourseResource
 from pipeline_dsl.concourse import concourse_context, subprocess
+from typing import Optional, Dict
+import os
 
 
 class GitRepoResource:
-    def __init__(self, name, uri, config):
+    def __init__(self, name: str, uri: str, config: dict) -> None:
         self.name = name
         self.config = config
         self.uri = uri
         if concourse_context():
             self.path = os.path.abspath(self.name)
         else:
-            self.path = os.getenv("HOME") + "/workspace/" + os.path.splitext(os.path.basename(uri))[0]
+            self.path = os.getenv("HOME", "") + "/workspace/" + os.path.splitext(os.path.basename(uri))[0]
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.path
 
-    def directory(self):
+    def directory(self) -> str:
         return self.path
 
     # Always returns the newest tag for the current version
-    def tag(self):
+    def tag(self) -> str:
         return subprocess.check_output(["git", "describe", "--tags"], cwd=self.path, stderr=subprocess.DEVNULL).decode("utf-8").strip()
 
     # Returns one tag for the current version
-    def ref(self):
+    def ref(self) -> str:
         if concourse_context():
             with open(os.path.join(self.path, ".git/ref")) as f:
                 return f.read().strip()
@@ -32,15 +34,26 @@ class GitRepoResource:
         except Exception:
             return subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=self.path).decode("utf-8").strip()
 
-    def short_ref(self):
+    def short_ref(self) -> str:
         if concourse_context():
             with open(os.path.join(self.path, ".git/short_ref")) as f:
                 return f.read().strip()
         return subprocess.check_output(["git", "rev-parse", "--short", "HEAD"], cwd=self.path).decode("utf-8").strip()
 
 
-class GitRepo:
-    def __init__(self, uri, username=None, password=None, branch=None, paths=None, ignore_paths=None, tag_filter=None, git_config={}, private_key=None):
+class GitRepo(AbstractResource[GitRepoResource]):
+    def __init__(
+        self,
+        uri: str,
+        username: str = None,
+        password: str = None,
+        branch: str = None,
+        paths: list = None,
+        ignore_paths: list = None,
+        tag_filter: str = None,
+        git_config: dict = {},
+        private_key: str = None,
+    ):
         self.uri = uri
         self.username = username
         self.password = password
@@ -51,15 +64,15 @@ class GitRepo:
         self.git_config = git_config
         self.private_key = private_key
 
-    def resource_type(self):
+    def resource_type(self) -> Optional[Dict]:
         return None
 
-    def concourse(self, name):
-        result = {
-            "name": name,
-            "type": "git",
-            "icon": "git",
-            "source": {
+    def concourse(self, name: str) -> ConcourseResource:
+        result = ConcourseResource(
+            name=name,
+            type="git",
+            icon="git",
+            source={
                 "uri": self.uri,
                 "branch": self.branch,
                 "username": self.username,
@@ -70,9 +83,11 @@ class GitRepo:
                 "git_config": list(map(lambda kv: {"name": kv[0], "value": kv[1]}, self.git_config.items())),
                 "private_key": self.private_key,
             },
-        }
-        result["source"] = dict(filter(lambda x: x[1] is not None, result["source"].items()))
+        )
+        result.source = dict(
+            filter(lambda x: x[1] is not None, result.source.items()),
+        )
         return result
 
-    def get(self, name):
+    def get(self, name: str) -> GitRepoResource:
         return GitRepoResource(name, self.uri, self.git_config)

--- a/pipeline_dsl/resources/pool.py
+++ b/pipeline_dsl/resources/pool.py
@@ -2,7 +2,7 @@ from pipeline_dsl.resources.resource import AbstractResource, ConcourseResource
 from typing import Optional, Dict
 
 
-class Pool(AbstractResource):
+class Pool(AbstractResource["Pool"]):
     def __init__(self, uri: str, branch: str, pool: str, username: str, password: str) -> None:
         self.uri = uri
         self.branch = branch

--- a/pipeline_dsl/resources/pool.py
+++ b/pipeline_dsl/resources/pool.py
@@ -1,9 +1,9 @@
-from typing import Optional, Dict
 from pipeline_dsl.resources.resource import AbstractResource, ConcourseResource
+from typing import Optional, Dict
 
 
 class Pool(AbstractResource):
-    def __init__(self, uri: str, branch: str, pool: str, username: str, password: str):
+    def __init__(self, uri: str, branch: str, pool: str, username: str, password: str) -> None:
         self.uri = uri
         self.branch = branch
         self.pool = pool

--- a/pipeline_dsl/resources/pypi.py
+++ b/pipeline_dsl/resources/pypi.py
@@ -2,7 +2,7 @@ from pipeline_dsl.resources.resource import AbstractResource, ConcourseResource
 from typing import Optional, Dict
 
 
-class PyPi(AbstractResource):
+class PyPi(AbstractResource["PyPi"]):
     def __init__(self, name: str, username: str, password: str) -> None:
         self.name = name
         self.username = username

--- a/pipeline_dsl/resources/pypi.py
+++ b/pipeline_dsl/resources/pypi.py
@@ -1,9 +1,9 @@
-from typing import Optional, Dict
 from pipeline_dsl.resources.resource import AbstractResource, ConcourseResource
+from typing import Optional, Dict
 
 
 class PyPi(AbstractResource):
-    def __init__(self, name: str, username: str, password: str):
+    def __init__(self, name: str, username: str, password: str) -> None:
         self.name = name
         self.username = username
         self.password = password

--- a/pipeline_dsl/resources/registry_image.py
+++ b/pipeline_dsl/resources/registry_image.py
@@ -5,7 +5,7 @@ import os
 
 
 class RegistryImageResource:
-    def __init__(self, name: str):
+    def __init__(self, name: str) -> None:
         self.name = name
         self.path = os.path.abspath(self.name)
 

--- a/pipeline_dsl/resources/semver.py
+++ b/pipeline_dsl/resources/semver.py
@@ -1,47 +1,76 @@
-import os
+from pipeline_dsl.resources.resource import AbstractResource, ConcourseResource
 from pipeline_dsl.concourse import concourse_context
+from typing import Optional, Dict, Any
+from abc import ABC, abstractmethod
+import os
 
 
 class SemVerResource:
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         self.name = name
         self.path = os.path.abspath(self.name)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
-    def version(self):
+    def version(self) -> str:
         if concourse_context():
             with open(os.path.join(self.path, "version")) as f:
                 return f.read().strip()
         return "0.0.1"
 
 
-class SemVer:
-    def __init__(self, source, initial_version=None):
-        self.source = source
+class SemVer(AbstractResource[SemVerResource]):
+    def __init__(self, driver: "SemVerDriver", initial_version: str = None):
+        self.driver = driver
         self.initial_version = initial_version
 
-    def resource_type(self):
+    def resource_type(self) -> Optional[dict]:
         return None
 
-    def concourse(self, name):
-        result = {
-            "name": name,
-            "type": "semver",
-            "icon": "creation",
-            "source": self.source.concourse(),
-        }
+    def concourse(self, name: str) -> ConcourseResource:
+        result = ConcourseResource(
+            name=name,
+            type="semver",
+            icon="creation",
+            source=self.driver.concourse(),
+        )
         if self.initial_version is not None:
-            result["source"]["initial_version"] = self.initial_version
+            result.source["initial_version"] = self.initial_version
         return result
 
-    def get(self, name):
+    def get(self, name: str) -> SemVerResource:
         return SemVerResource(name)
 
 
-class SemVerGitDriver:
-    def __init__(self, uri, branch, file, private_key=None, username=None, password=None, git_user=None, depth=None, skip_ssl_verification=None, commit_message=None):
+class SemVerDriver(ABC):
+    @abstractmethod
+    def resource_type(self) -> Optional[Dict]:
+        pass
+
+    @abstractmethod
+    def concourse(self) -> Dict[str, Any]:
+        pass
+
+    @abstractmethod
+    def get(self) -> None:
+        pass
+
+
+class SemVerGitDriver(SemVerDriver):
+    def __init__(
+        self,
+        uri: str,
+        branch: str,
+        file: str,
+        private_key: str = None,
+        username: str = None,
+        password: str = None,
+        git_user: str = None,
+        depth: str = None,
+        skip_ssl_verification: bool = None,
+        commit_message: str = None,
+    ):
         self.uri = uri
         self.branch = branch
         self.file = file
@@ -53,10 +82,10 @@ class SemVerGitDriver:
         self.skip_ssl_verification = skip_ssl_verification
         self.commit_message = commit_message
 
-    def resource_type(self):
+    def resource_type(self) -> Optional[Dict]:
         return None
 
-    def concourse(self):
+    def concourse(self) -> Dict[str, Any]:
         result = {
             "driver": "git",
             "uri": self.uri,
@@ -71,7 +100,9 @@ class SemVerGitDriver:
             "commit_message": self.commit_message,
         }
 
-        return dict(filter(lambda x: x[1] is not None, result.items()))
+        return dict(
+            filter(lambda x: x[1] is not None, result.items()),
+        )
 
-    def get(self, name):
+    def get(self) -> None:
         return None

--- a/pipeline_dsl/resources/semver.py
+++ b/pipeline_dsl/resources/semver.py
@@ -45,15 +45,7 @@ class SemVer(AbstractResource[SemVerResource]):
 
 class SemVerDriver(ABC):
     @abstractmethod
-    def resource_type(self) -> Optional[Dict]:
-        pass
-
-    @abstractmethod
     def concourse(self) -> Dict[str, Any]:
-        pass
-
-    @abstractmethod
-    def get(self) -> None:
         pass
 
 
@@ -82,9 +74,6 @@ class SemVerGitDriver(SemVerDriver):
         self.skip_ssl_verification = skip_ssl_verification
         self.commit_message = commit_message
 
-    def resource_type(self) -> Optional[Dict]:
-        return None
-
     def concourse(self) -> Dict[str, Any]:
         result = {
             "driver": "git",
@@ -103,6 +92,3 @@ class SemVerGitDriver(SemVerDriver):
         return dict(
             filter(lambda x: x[1] is not None, result.items()),
         )
-
-    def get(self) -> None:
-        return None

--- a/pipeline_dsl/test/test_resource.py
+++ b/pipeline_dsl/test/test_resource.py
@@ -9,13 +9,13 @@ class TestGitResource(unittest.TestCase):
         repo = GitRepo("https://example.com/repo.git", git_config={"user.name": "unknown", "user.email": "unknown@example.com"})
 
         obj = repo.concourse(name="test")
-        self.assertDictEqual(
+        self.assertEqual(
             obj,
-            {
-                "name": "test",
-                "type": "git",
-                "icon": "git",
-                "source": {
+            ConcourseResource(
+                name="test",
+                type="git",
+                icon="git",
+                source={
                     "uri": "https://example.com/repo.git",
                     "git_config": [
                         {
@@ -28,7 +28,7 @@ class TestGitResource(unittest.TestCase):
                         },
                     ],
                 },
-            },
+            ),
         )
 
     def test_path(self):
@@ -42,17 +42,17 @@ class TestCronResource(unittest.TestCase):
         repo = Cron("definition")
 
         obj = repo.concourse("test")
-        self.assertDictEqual(
+        self.assertEqual(
             obj,
-            {
-                "name": "test",
-                "type": "cron",
-                "icon": "clock-outline",
-                "source": {
+            ConcourseResource(
+                name="test",
+                type="cron",
+                icon="clock-outline",
+                source={
                     "cron": "definition",
                     "location": "Europe/Berlin",
                 },
-            },
+            ),
         )
 
         obj = repo.resource_type()
@@ -74,19 +74,19 @@ class TestDockerImageResource(unittest.TestCase):
         resource = DockerImage("repo", "username", "password", "tag")
 
         obj = resource.concourse("test")
-        self.assertDictEqual(
+        self.assertEqual(
             obj,
-            {
-                "name": "test",
-                "type": "docker-image",
-                "icon": "docker",
-                "source": {
+            ConcourseResource(
+                name="test",
+                type="docker-image",
+                icon="docker",
+                source={
                     "repository": "repo",
                     "username": "username",
                     "password": "password",
                     "tag": "tag",
                 },
-            },
+            ),
         )
 
         location = resource.get("test")
@@ -98,18 +98,18 @@ class TestGoogleCloudStorageResource(unittest.TestCase):
         resource = GoogleCloudStorage("bucket", "regexp", "credentials")
 
         obj = resource.concourse("test")
-        self.assertDictEqual(
+        self.assertEqual(
             obj,
-            {
-                "name": "test",
-                "type": "gcs",
-                "icon": "file-cloud",
-                "source": {
+            ConcourseResource(
+                name="test",
+                type="gcs",
+                icon="file-cloud",
+                source={
                     "bucket": "bucket",
                     "regexp": "regexp",
                     "json_key": "credentials",
                 },
-            },
+            ),
         )
 
         self.assertDictEqual(
@@ -164,13 +164,13 @@ class TestGithubResource(unittest.TestCase):
         resource = GithubRelease("owner", "repo", "access_token", pre_release=True, release=False, github_api_url="github_api_url/v3", github_uploads_url="github_uploads_url")
 
         obj = resource.concourse("test")
-        self.assertDictEqual(
+        self.assertEqual(
             obj,
-            {
-                "name": "test",
-                "type": "github-release",
-                "icon": "github",
-                "source": {
+            ConcourseResource(
+                name="test",
+                type="github-release",
+                icon="github",
+                source={
                     "owner": "owner",
                     "repository": "repo",
                     "access_token": "access_token",
@@ -180,7 +180,7 @@ class TestGithubResource(unittest.TestCase):
                     "github_v4_api_url": "github_api_url/graphql",
                     "github_uploads_url": "github_uploads_url",
                 },
-            },
+            ),
         )
 
 
@@ -201,13 +201,13 @@ class TestSemVerResource(unittest.TestCase):
         )
         obj = resource.concourse("test")
 
-        self.assertDictEqual(
+        self.assertEqual(
             obj,
-            {
-                "name": "test",
-                "type": "semver",
-                "icon": "creation",
-                "source": {
+            ConcourseResource(
+                name="test",
+                type="semver",
+                icon="creation",
+                source={
                     "driver": "git",
                     "uri": "git@github.com:concourse/concourse.git",
                     "branch": "version",
@@ -219,7 +219,7 @@ class TestSemVerResource(unittest.TestCase):
                     "skip_ssl_verification": True,
                     "commit_message": "Commit Message",
                 },
-            },
+            ),
         )
 
     def test_password(self):
@@ -238,13 +238,13 @@ class TestSemVerResource(unittest.TestCase):
         )
         obj = resource.concourse("test")
 
-        self.assertDictEqual(
+        self.assertEqual(
             obj,
-            {
-                "name": "test",
-                "type": "semver",
-                "icon": "creation",
-                "source": {
+            ConcourseResource(
+                name="test",
+                type="semver",
+                icon="creation",
+                source={
                     "driver": "git",
                     "uri": "git@github.com:concourse/concourse.git",
                     "branch": "version",
@@ -256,7 +256,7 @@ class TestSemVerResource(unittest.TestCase):
                     "skip_ssl_verification": True,
                     "commit_message": "Commit Message",
                 },
-            },
+            ),
         )
 
 
@@ -289,19 +289,19 @@ class TestGithubPRResource(unittest.TestCase):
 
         obj = resource.concourse("test")
 
-        self.assertDictEqual(
+        self.assertEqual(
             obj,
-            {
-                "name": "test",
-                "type": "github-pr",
-                "icon": "source-pull",
-                "source": {
+            ConcourseResource(
+                name="test",
+                type="github-pr",
+                icon="source-pull",
+                source={
                     "repository": "torvalds/linux",
                     "access_token": "((GITHUB_TOKEN))",
                     "skip_ssl_verification": True,
                     "v3_endpoint": "https://api.example.com",
                 },
-            },
+            ),
         )
 
 


### PR DESCRIPTION
This PR introduces type hints for the remaining pipeline-dsl resources, namely:
- `cron`
- `docker`
- `gcs`
- `git`
- `github`
- `github pr`
- `semver`

*NOTE*: It also fixes the missing type hint for the `__init__` method of the `registry_image`, `pool` & `pypi` resource.