### PR TITLE
Fix some compliacne problems

### DIFF
--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -58,7 +58,7 @@ APPENDIX: How to apply the Apache License to your work.
 
 To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
 
-Copyright 2020-2021 SAP SE or an SAP affiliate company and pipeline-dsl contributors
+Copyright [yyyy] [name of copyright owner]
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![python](https://img.shields.io/badge/python-3.7-blue.svg)](https://pypi.org/project/pipeline-dsl/)
 [![pypi](https://img.shields.io/pypi/v/pipeline-dsl.svg)](https://pypi.org/project/pipeline-dsl/)
 [![license](https://img.shields.io/pypi/l/pipeline-dsl.svg)](https://pypi.org/project/pipeline-dsl/)
+[![REUSE status](https://api.reuse.software/badge/github.com/SAP/pipeline-dsl)](https://api.reuse.software/info/github.com/SAP/pipeline-dsl)
 
 ## Features
 


### PR DESCRIPTION
See https://github.com/SAP/fosstars-oss-rules-of-play-report/blob/22d8b55f274a8943103040d9c14fb78b16ebfbaf/SAP/pipeline-dsl.md#rl-reuse_tool-2
and https://github.com/SAP/fosstars-oss-rules-of-play-report/blob/22d8b55f274a8943103040d9c14fb78b16ebfbaf/SAP/pipeline-dsl.md#rl-reuse_tool-1

TL;DR
- ran `reuse download --all`
- ran `cp LICENSES/Apache-2.0.txt LICENSE` (to not have two different formattings of the same license text in the repo) and change `[yyyy]` and `[name of copyright owner]` placeholders.
- add badge to readme