### PR TITLE
Add get_params field to PutStep

### DIFF
--- a/pipeline_dsl/concourse/job.py
+++ b/pipeline_dsl/concourse/job.py
@@ -42,11 +42,11 @@ class Job:
         self.inputs.append(name)
         return resource_chain.resource.get(name)
 
-    def put(self, name, params=None):
+    def put(self, name, params=None, get_params=None):
         resource_chain = self.resource_chains.get(name, None)
         if not resource_chain:
             raise Exception("Resource " + name + " not configured for pipeline")
-        self.plan.append(PutStep(name, params))
+        self.plan.append(PutStep(name, params, get_params))
         resource_chain.passed.append(self.name)
         self.inputs.append(name)
         return resource_chain.resource.get(name)
@@ -134,15 +134,19 @@ class GetStep:
 
 
 class PutStep:
-    def __init__(self, name, params):
+    def __init__(self, name, params, get_params=None):
         self.name = name
         self.params = params
+        self.get_params = get_params
 
     def concourse(self):
-        return {
+        result = {
             "put": self.name,
             "params": self.params,
         }
+        if self.get_params is not None:
+            result["get_params"] = self.get_params
+        return result
 
 
 class TryStep:
@@ -201,8 +205,8 @@ class ParallelStep:
         self.job.inputs.append(name)
         return resource_chain.resource.get(name)
 
-    def put(self, name, params=None):
-        self.tasks.append(PutStep(name, params))
+    def put(self, name, params=None, get_params=None):
+        self.tasks.append(PutStep(name, params, get_params))
 
     def concourse(self):
         return {

--- a/pipeline_dsl/test/test_job.py
+++ b/pipeline_dsl/test/test_job.py
@@ -26,7 +26,7 @@ class TestJobSimple(unittest.TestCase):
         with Pipeline("test", script_dirs={"fake": "fake_scripts"}) as pipeline:
             job = pipeline.job("job")
 
-            job.on_success = PutStep("test_res_success", {"param": "success"})
+            job.on_success = PutStep("test_res_success", {"param": "success"}, get_params={"test": True})
             job.on_failure = PutStep("test_res_fail", {"param": "fail"})
             job.on_abort = PutStep("test_res_abort", {"param": "abort"})
             job.ensure = GetStep("test_res_ensure", False, ["job-1"], {"param": "ensure"}, version="every")
@@ -44,6 +44,7 @@ class TestJobSimple(unittest.TestCase):
                     "on_success": {
                         "put": "test_res_success",
                         "params": {"param": "success"},
+                        "get_params": {"test": True},
                     },
                     "on_failure": {
                         "put": "test_res_fail",
@@ -73,10 +74,11 @@ class TestJobSimple(unittest.TestCase):
             job.get("res-1", False, ["testjob"], params={"test": 1})
             job.get("res-2", True, ["testjob2"], params={"test": 2})
 
-            job.put("res-1", {"test": 3})
+            job.put("res-1", {"test": 3}, get_params={"test": True})
             job.put("res-2", {"test": 4})
 
             obj = job.concourse()
+            self.maxDiff = None
 
             obj["plan"] = obj["plan"][1:]  # remove init task. it is checked test_pipeline.py
             self.assertDictEqual(
@@ -99,6 +101,7 @@ class TestJobSimple(unittest.TestCase):
                         {
                             "put": "res-1",
                             "params": {"test": 3},
+                            "get_params": {"test": True},
                         },
                         {
                             "put": "res-2",

--- a/pipeline_dsl/test/test_job.py
+++ b/pipeline_dsl/test/test_job.py
@@ -78,7 +78,6 @@ class TestJobSimple(unittest.TestCase):
             job.put("res-2", {"test": 4})
 
             obj = job.concourse()
-            self.maxDiff = None
 
             obj["plan"] = obj["plan"][1:]  # remove init task. it is checked test_pipeline.py
             self.assertDictEqual(


### PR DESCRIPTION
## Motivation

At the moment the `PutStep` doesn't support the [`get_params` field](https://concourse-ci.org/jobs.html#schema.step.put-step.get_params). This PR will add it to the PutStep as an optional field and it won't break anything.
For example, the [Concourse PR Resource](https://github.com/telia-oss/github-pr-resource) is using it sometimes.