### PR TITLE
Add fetch_tags field to git resource

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -54,7 +54,7 @@ GoogleCloudStorageResource("my-bucket", "(.*).txt", "((MY_GCS_CREDENTIALS))")
 
 Upstream resource documentation: https://github.com/concourse/git-resource/blob/master/README.md
 
-Note: Only `uri`, `username`, `password`, `branch`, `ignore_paths`, `tag_filter`, `git_config` and `private_key` are currently supported supported in source configuration.
+Note: Only `uri`, `username`, `password`, `branch`, `ignore_paths`, `tag_filter`, `fetch_tags`, `git_config` and `private_key` are currently supported supported in source configuration.
 
 Example:
 ```python

--- a/pipeline_dsl/resources/git.py
+++ b/pipeline_dsl/resources/git.py
@@ -53,6 +53,7 @@ class GitRepo(AbstractResource[GitRepoResource]):
         tag_filter: str = None,
         git_config: dict = {},
         private_key: str = None,
+        fetch_tags: bool = None,
     ):
         self.uri = uri
         self.username = username
@@ -63,6 +64,7 @@ class GitRepo(AbstractResource[GitRepoResource]):
         self.tag_filter = tag_filter
         self.git_config = git_config
         self.private_key = private_key
+        self.fetch_tags = fetch_tags
 
     def resource_type(self) -> Optional[Dict]:
         return None
@@ -82,6 +84,7 @@ class GitRepo(AbstractResource[GitRepoResource]):
                 "tag_filter": self.tag_filter,
                 "git_config": list(map(lambda kv: {"name": kv[0], "value": kv[1]}, self.git_config.items())),
                 "private_key": self.private_key,
+                "fetch_tags": self.fetch_tags,
             },
         )
         result.source = dict(

--- a/pipeline_dsl/test/test_resource.py
+++ b/pipeline_dsl/test/test_resource.py
@@ -36,6 +36,28 @@ class TestGitResource(unittest.TestCase):
             repo = GitRepo("https://example.com/repo.git", git_config={"user.name": "unknown", "user.email": "unknown@example.com"})
             self.assertEqual(repo.get("xxx").path, os.path.join(os.environ["HOME"], "workspace", "repo"))
 
+    def test_tags(self):
+        repo = GitRepo("https://example.com/repo.git", git_config={"user.name": "unknown", "user.email": "unknown@example.com"}, fetch_tags=True)
+
+        obj = repo.concourse(name="test")
+        self.assertEqual(
+            obj.source,
+            {
+                "uri": "https://example.com/repo.git",
+                "git_config": [
+                    {
+                        "name": "user.name",
+                        "value": "unknown",
+                    },
+                    {
+                        "name": "user.email",
+                        "value": "unknown@example.com",
+                    },
+                ],
+                "fetch_tags": True,
+            },
+        )
+
 
 class TestCronResource(unittest.TestCase):
     def test_basic(self):


### PR DESCRIPTION
## Motivation
At the moment the Git (repo) resource doesn't have the [`fetch_tags` field](https://github.com/concourse/git-resource#source-configuration), which enables the git resource to fetch all tags.

## Note
We need this for our new PR release process.