### PR TITLE
add utils/*.sh to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,4 +22,10 @@ setuptools.setup(
         "pyyaml",
     ],
     python_requires=">=3.7",
+    package_dir={
+        "pipeline_dsl.utils": "pipeline_dsl/utils/",
+    },
+    package_data={
+        "pipeline_dsl.utils": ["*.sh"],
+    },
 )


### PR DESCRIPTION
If you install the pipeline_dsl with pip and try to use `docker_daemon()` from `utils` it currently fails with:

```
scripts/pythonpath/pipeline_dsl/utils/start-docker.sh
Error: [Errno 2] No such file or directory: 'scripts/pythonpath/pipeline_dsl/utils/start-docker.sh'
     At /tmp/build/05dd5dda/scripts/pythonpath/pipeline_dsl/concourse/pipeline.py:144 in function main
     At /tmp/build/05dd5dda/scripts/pythonpath/pipeline_dsl/concourse/pipeline.py:93 in function run_task
     At /tmp/build/05dd5dda/scripts/pythonpath/pipeline_dsl/concourse/job.py:112 in function run_task
     At /tmp/build/05dd5dda/scripts/pythonpath/pipeline_dsl/concourse/task.py:59 in function fn
  *  At scripts/starter/pipeline.py:137 in function install_kpack
     At /usr/lib/python3.8/contextlib.py:113 in function __enter__
     At /tmp/build/05dd5dda/scripts/pythonpath/pipeline_dsl/utils/docker_daemon.py:15 in function docker_daemon
     At /tmp/build/05dd5dda/scripts/pythonpath/pipeline_dsl/shell.py:20 in function shell
     At /usr/lib/python3.8/subprocess.py:493 in function run
     At /usr/lib/python3.8/subprocess.py:858 in function __init__
     At /usr/lib/python3.8/subprocess.py:1704 in function _execute_child
```

(I works when using it with `PYTHONPATH`)

This PR makes sure `setup.py` will also include the `utils/start-docker.sh` and `utils/stop-docker.sh` scripts.