### PR TITLE
Pin github-release resource

### DIFF
--- a/pipeline_dsl/resources/github.py
+++ b/pipeline_dsl/resources/github.py
@@ -48,7 +48,14 @@ class GithubRelease(AbstractResource[GithubReleaseResource]):
         self.order_by = order_by
 
     def resource_type(self) -> Optional[dict]:
-        return None
+        return {
+            "name": "github-release",
+            "type": "docker-image",
+            "source": {
+                "repository": "concourse/github-release-resource",
+                "tag": "1.6.3",
+            },
+        }
 
     def concourse(self, name: str) -> ConcourseResource:
         result = ConcourseResource(


### PR DESCRIPTION
The current `github-release` concourse resources expects a field which is not yet present in the enterprise version of our GihHub. This downgrades and pins the version until a update is provided.

See https://github.com/concourse/github-release-resource/issues/109 for more details.
